### PR TITLE
Add GitHub Actions workflow for NuGet package publishing

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -28,18 +28,15 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Run tests
-      run: dotnet test GenericEFCoreHelper.Tests/GenericEFCoreHelper.Tests.csproj --configuration Release --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal
 
     - name: Pack
-      if: success()
       run: dotnet pack --configuration Release --no-build --output ./nuget
 
     - name: List package files
-      if: success()
       run: ls -la ./nuget
 
     - name: Publish to NuGet
-      if: success()
       env:
         NUGET_API_KEY: ${{ secrets.GENERICEFCOREHELPER_APIKEY }}
       run: dotnet nuget push ./nuget/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -27,15 +27,16 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
 
-    - name: List test DLLs
-      run: ls -la GenericEFCoreHelper.Tests/bin/Release/net9.0/
-
     - name: Run tests
       run: dotnet test GenericEFCoreHelper.Tests/GenericEFCoreHelper.Tests.csproj --configuration Release --no-build --verbosity normal
 
     - name: Pack
       if: success()
       run: dotnet pack --configuration Release --no-build
+
+    - name: List package files
+      if: success()
+      run: ls -la bin/Release
 
     - name: Publish to NuGet
       if: success()

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
 
+    - name: List test DLLs
+      run: ls -la GenericEFCoreHelper.Tests/bin/Debug/net9.0/
+
     - name: Run tests
       run: dotnet test GenericEFCoreHelper.Tests/GenericEFCoreHelper.Tests.csproj --no-build --verbosity normal
 

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -41,6 +41,6 @@ jobs:
     - name: Publish to NuGet
       if: success()
       env:
-        NUGET_API_KEY: ${{ secrets.GENERICEFCOREHELPER_APIKEY }}
+        NUGET_API_KEY: ${{ secrets.GEFCOREHELPER_APIKEY }}
       run: dotnet nuget push ./nuget/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -38,9 +38,13 @@ jobs:
       if: success()
       run: ls -la ./nuget
 
+    - name: Log masked API key
+      if: success()
+      run: echo "API Key fetched: ${NUGET_API_KEY:0:4}****"
+
     - name: Publish to NuGet
       if: success()
       env:
-        NUGET_API_KEY: ${{ secrets.GEFCOREHELPER_APIKEY }}
+        NUGET_API_KEY: ${{ secrets.GENERICEFCOREHELPER_APIKEY }}
       run: dotnet nuget push ./nuget/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -28,15 +28,19 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Run tests
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --configuration Release --no-build --verbosity normal
 
     - name: Pack
+      if: success()
       run: dotnet pack --configuration Release --no-build --output ./nuget
 
     - name: List package files
+      if: success()
       run: ls -la ./nuget
 
     - name: Publish to NuGet
+      if: success()
       env:
         NUGET_API_KEY: ${{ secrets.GENERICEFCOREHELPER_APIKEY }}
       run: dotnet nuget push ./nuget/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,41 @@
+name: Publish NuGet Package
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Run tests
+      run: dotnet test GenericEFCoreHelper.Tests/GenericEFCoreHelper.Tests.csproj --no-build --verbosity normal
+
+    - name: Pack
+      if: success()
+      run: dotnet pack --configuration Release --no-build
+
+    - name: Publish to NuGet
+      if: success()
+      env:
+        NUGET_API_KEY: ${{ secrets.GENERICEFCOREHELPER_APIKEY }}
+      run: dotnet nuget push bin/Release/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -28,10 +28,10 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: List test DLLs
-      run: ls -la GenericEFCoreHelper.Tests/bin/Debug/net9.0/
+      run: ls -la GenericEFCoreHelper.Tests/bin/Release/net9.0/
 
     - name: Run tests
-      run: dotnet test GenericEFCoreHelper.Tests/GenericEFCoreHelper.Tests.csproj --no-build --verbosity normal
+      run: dotnet test GenericEFCoreHelper.Tests/GenericEFCoreHelper.Tests.csproj --configuration Release --no-build --verbosity normal
 
     - name: Pack
       if: success()

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -32,14 +32,14 @@ jobs:
 
     - name: Pack
       if: success()
-      run: dotnet pack --configuration Release --no-build
+      run: dotnet pack --configuration Release --no-build --output ./nuget
 
     - name: List package files
       if: success()
-      run: ls -la bin/Release
+      run: ls -la ./nuget
 
     - name: Publish to NuGet
       if: success()
       env:
         NUGET_API_KEY: ${{ secrets.GENERICEFCOREHELPER_APIKEY }}
-      run: dotnet nuget push bin/Release/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./nuget/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Add GitHub Actions workflow for NuGet package publishing

Introduce `nuget-publish.yml` to automate NuGet package publishing.
The workflow triggers on push and pull request to `main` branch.
It includes steps for checking out code, setting up .NET 9.0.x,
restoring dependencies, building, testing, packing, and publishing
the NuGet package using a secret API key.