### PR TITLE
Refactor nuget-publish.yml without functional changes

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -48,4 +48,4 @@ jobs:
       if: success()
       env:
         NUGET_API_KEY: ${{ secrets.GEFCOREHELPER_APIKEY }}
-      run: dotnet nuget push ./nuget/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./nuget/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json 


### PR DESCRIPTION
Refactor nuget-publish.yml without functional changes

The `run` command for the "Publish to NuGet" job in the `nuget-publish.yml` file was removed and re-added without any changes to the command itself. This modification does not alter the functionality of the script and may have been done for formatting or other non-functional reasons.