### PR TITLE
Update ServiceRegister in Readme.md for EF Core helper

### DIFF
--- a/GenericEFCoreHelper/GenericEFCoreHelper.csproj
+++ b/GenericEFCoreHelper/GenericEFCoreHelper.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>GenericEFCoreHelper</PackageId>
-    <Version>1.0.5</Version>
+    <Version>2.0.0</Version>
     <Authors>Mohammed Rehan Javed</Authors>
     <Company>MRJaved</Company>
     <Description>A helper library for Entity Framework Core.</Description>

--- a/GenericEFCoreHelper/GenericEFCoreHelper.csproj
+++ b/GenericEFCoreHelper/GenericEFCoreHelper.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>GenericEFCoreHelper</PackageId>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <Authors>Mohammed Rehan Javed</Authors>
     <Company>MRJaved</Company>
     <Description>A helper library for Entity Framework Core.</Description>

--- a/GenericEFCoreHelper/Readme.md
+++ b/GenericEFCoreHelper/Readme.md
@@ -27,7 +27,9 @@ public static class ServiceRegister
         // Configure Entity Framework Core 
         var connectionString = configuration["ConnectionStrings:DemoWebAppConnectionString"] ?? throw new InvalidOperationException("Connection string 'DemoWebAppConnectionString' not found."); services.AddDbContext(options => options.UseSqlServer(connectionString), ServiceLifetime.Singleton);
         // Register Repositories
-        services.AddScoped(typeof(IGenericRepository<,>), typeof(GenericRepository<,>));
+        services.AddGenericEFCHelperRepository();
+        //Also we can register the lifetime of the instance
+        //services.AddGenericEFCHelperRepository(ServiceLifetime.Scoped);
 
         services.AddTransient<IEmployeeService, EmployeeService>();
     }


### PR DESCRIPTION
Update ServiceRegister in Readme.md for EF Core helper

Added a method call to register a generic EF Core helper repository.
Removed the previous scoped generic repository registration.
Included a comment about specifying the instance lifetime.